### PR TITLE
Reference node accepts all cases of "ID"

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -21,7 +21,7 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        if ref = document.dup.at_xpath("//*[@ID='#{id}' or @wsu:Id='#{id}']", NAMESPACES)
+        if ref = document.dup.at_xpath("//*[@ID='#{id}' or @Id='#{id}' or @id='#{id}' or @wsu:Id='#{id}']", NAMESPACES)
           ref
         else
           raise(


### PR DESCRIPTION
Croatian fiscalization needs the referenced nodes "ID" to be lower-case and this fix is needed to sign the XML request.
I've also added another variation of it ("Id"), just in case it's needed.