### PR TITLE
SignedDocument accepts nokogiri document

### DIFF
--- a/lib/xmldsig/signed_document.rb
+++ b/lib/xmldsig/signed_document.rb
@@ -3,7 +3,11 @@ module Xmldsig
     attr_accessor :document
 
     def initialize(document, options = {})
-      @document = Nokogiri::XML(document, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
+      @document = if document.kind_of?(Nokogiri::XML::Document)
+        document
+      else
+        Nokogiri::XML(document, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
+      end
     end
 
     def validate(certificate = nil, &block)

--- a/spec/lib/xmldsig/signed_document_spec.rb
+++ b/spec/lib/xmldsig/signed_document_spec.rb
@@ -26,6 +26,12 @@ describe Xmldsig::SignedDocument do
         described_class.new(badly_formed)
       }.to raise_error
     end
+
+    it "accepts a nokogiri document" do
+      doc = Nokogiri::XML(unsigned_xml)
+      signed_document = described_class.new(doc)
+      signed_document.document.should be_a(Nokogiri::XML::Document)
+    end
   end
 
   describe "#signatures" do


### PR DESCRIPTION
This PR adds the ability to pass in a `Nokogiri::XML::Document` to `Xmldsig::SignedDocument`. See https://github.com/benoist/xmldsig/issues/15 for context.

While it makes more sense to me to add a new class named `Xmldsig::UnsignedDocument`, I went this route because it minimizes changes and does not disturb the existing interface.