### PR TITLE
Support for custom id attribute name

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -1,13 +1,14 @@
 module Xmldsig
   class Reference
-    attr_accessor :reference, :errors
+    attr_accessor :reference, :errors, :id_attr
 
     class ReferencedNodeNotFound < Exception;
     end
 
-    def initialize(reference)
+    def initialize(reference, id_attr = nil)
       @reference = reference
       @errors    = []
+      @id_attr = id_attr
     end
 
     def document
@@ -21,7 +22,8 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        if ref = document.dup.at_xpath("//*[@ID='#{id}' or @wsu:Id='#{id}']", NAMESPACES)
+        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}='#{id}']" : "//*[@ID='#{id}' or @wsu:Id='#{id}']"
+        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES)
           ref
         else
           raise(

--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -2,13 +2,14 @@ module Xmldsig
   class Signature
     attr_accessor :signature
 
-    def initialize(signature)
+    def initialize(signature, id_attr = nil)
       @signature = signature
+      @id_attr = id_attr
     end
 
     def references
       @references ||= signature.xpath("descendant::ds:Reference", NAMESPACES).map do |node|
-        Reference.new(node)
+        Reference.new(node, @id_attr)
       end
     end
 
@@ -17,7 +18,7 @@ module Xmldsig
     end
 
     def sign(private_key = nil, &block)
-      references.each(&:sign)
+      references.each { |reference| reference.sign }
       self.signature_value = calculate_signature_value(private_key, &block)
     end
 

--- a/lib/xmldsig/signed_document.rb
+++ b/lib/xmldsig/signed_document.rb
@@ -1,6 +1,6 @@
 module Xmldsig
   class SignedDocument
-    attr_accessor :document
+    attr_accessor :document, :id_attr
 
     def initialize(document, options = {})
       @document = if document.kind_of?(Nokogiri::XML::Document)
@@ -8,6 +8,7 @@ module Xmldsig
       else
         Nokogiri::XML(document, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
       end
+      @id_attr = options[:id_attr] if options[:id_attr]
     end
 
     def validate(certificate = nil, &block)
@@ -24,7 +25,7 @@ module Xmldsig
     end
 
     def signatures
-      document.xpath("//ds:Signature", NAMESPACES).reverse.collect { |node| Signature.new(node) } || []
+      document.xpath("//ds:Signature", NAMESPACES).reverse.collect { |node| Signature.new(node, @id_attr) } || []
     end
   end
 end

--- a/spec/fixtures/signed_custom_attribute_id.xml
+++ b/spec/fixtures/signed_custom_attribute_id.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" MyID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <ds:DigestValue>/GxRLc5AEfTmGlQFGC++jLfhJNE=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>QRr9nX1iGo0OwKsxOMsvoMQ8oWtl5NS9w8JzF3/+DcbLU1oNriaNKM7HixPH
+TQyyPgwn1Ysvyf0twWhiZ7TnPQ71EFcJFKCexGGC6SaChSIIJjnVukmUC6Le
+NdazERYV+QZZV5pmq5EfgW3RfDOinBXsMRuTDR8y1iG6K1gMKws=</ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned_custom_attribute_id.xml
+++ b/spec/fixtures/unsigned_custom_attribute_id.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" MyID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -48,6 +48,16 @@ describe Xmldsig::Reference do
         should == 'foo'
     end
 
+    it "returns the reference node when using a custom id attribute" do
+      node = document.at_xpath('//*[@ID]')
+      node.remove_attribute('ID')
+      node.set_attribute('MyID', 'foo')
+      reference = Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES), 'MyID')
+
+      reference.referenced_node.to_s.should ==
+        document.at_xpath("//*[@MyID='foo']").to_s
+    end
+
     it "raises ReferencedNodeNotFound when the refenced node is not present" do
       node = document.at_xpath('//*[@ID]')
       node.remove_attribute('ID')

--- a/spec/lib/xmldsig_spec.rb
+++ b/spec/lib/xmldsig_spec.rb
@@ -44,4 +44,37 @@ describe Xmldsig do
     end
   end
 
+  describe "Allows specifying a custom id attribute" do
+    context "an unsigned document" do
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned_custom_attribute_id.xml") }
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, :id_attr => 'MyID') }
+      let(:signed_document) { unsigned_document.sign(private_key) }
+
+      it "should be signable an validateable" do
+        Xmldsig::SignedDocument.new(signed_document, :id_attr => 'MyID').validate(certificate).should be == true
+      end
+
+      it 'should have a signature element' do
+        Xmldsig::SignedDocument.new(signed_document, :id_attr => 'MyID').signatures.count.should == 1
+      end
+
+      # TODO: remove this verification step when library matures
+      # it 'matches the result from xmlsec1' do
+      #   document = "spec/fixtures/unsigned_custom_attribute_id.xml"
+      #   result = `xmlsec1 --sign --privkey-pem spec/fixtures/key.pem --id-attr:MyID Foo #{document}`
+      #   result.gsub!("\n", '')
+      #   signed_document.gsub!("\n", '')
+      #   result.should == signed_document
+      # end
+    end
+
+    context "a signed document" do
+      let(:signed_xml) { File.read("spec/fixtures/signed_custom_attribute_id.xml") }
+      let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml, :id_attr => 'MyID') }
+
+      it "should be validateable" do
+        signed_document.validate(certificate).should be == true
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull-request allows to specify an option `:id_attr` when creating a new signed document, with the name of the ID attribute to use to identify the referenced node. This is useful for example for SAML assertions, that are of the form:

```xml
<saml:Assertion AssertionID="_6dec3ab3-7024-41f0-8b11-a88eb771d09b" ... 
....
      <ds:Reference URI="#_6dec3ab3-7024-41f0-8b11-a88eb771d09b">
```

With `AssertionID` as the name for the id attribute.

