### PR TITLE
Fix XPath injection in Reference handling.

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -22,8 +22,8 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}='#{id}']" : "//*[@ID='#{id}' or @wsu:Id='#{id}']"
-        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES)
+        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
+        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, { 'uri' => id })
           ref
         else
           raise(

--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -24,7 +24,7 @@ module Xmldsig
         id = reference_uri[1..-1]
         referenced_node_xpath = @id_attr ? "//*[@$idattr=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
         variable_bindings = { 'uri' => id }
-        variable_bindings['idattr'] = @id_attr
+        variable_bindings['idattr'] = @id_attr if @id_attr
         if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, variable_bindings)
           ref
         else

--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -22,8 +22,10 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
-        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, { 'uri' => id })
+        referenced_node_xpath = @id_attr ? "//*[@$idattr=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
+        variable_bindings = { 'uri' => id }
+        variable_bindings['idattr'] = @id_attr
+        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, variable_bindings)
           ref
         else
           raise(


### PR DESCRIPTION
I believe this is same issue uncovered in the onelogin/ruby-saml project. I could be wrong, but I'm opening this early to get more :eyes: on it. 

See https://github.com/onelogin/ruby-saml/pull/225 for details, specifically: 
https://github.com/onelogin/ruby-saml/pull/225/files#diff-661b9d9743a3ff77661f224c6191165cR259

Also related: https://github.com/rubysec/ruby-advisory-db/pull/163

Todo:

- [ ] Tests
- [ ] :tada: