### PR TITLE
XPath injection round 2.

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -22,8 +22,8 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}='#{id}']" : "//*[@ID='#{id}' or @wsu:Id='#{id}']"
-        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES)
+        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
+        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, { 'uri' => id })
           ref
         else
           raise(

--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -22,9 +22,8 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        referenced_node_xpath = @id_attr ? "//*[@$idattr=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
+        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
         variable_bindings = { 'uri' => id }
-        variable_bindings['idattr'] = @id_attr if @id_attr
         if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, variable_bindings)
           ref
         else

--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -24,7 +24,7 @@ module Xmldsig
         id = reference_uri[1..-1]
         referenced_node_xpath = @id_attr ? "//*[@$idattr=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
         variable_bindings = { 'uri' => id }
-        variable_bindings['idattr'] = @id_attr
+        variable_bindings['idattr'] = @id_attr if @id_attr
         if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, variable_bindings)
           ref
         else

--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -22,8 +22,10 @@ module Xmldsig
     def referenced_node
       if reference_uri && reference_uri != ""
         id = reference_uri[1..-1]
-        referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
-        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, { 'uri' => id })
+        referenced_node_xpath = @id_attr ? "//*[@$idattr=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
+        variable_bindings = { 'uri' => id }
+        variable_bindings['idattr'] = @id_attr
+        if ref = document.dup.at_xpath(referenced_node_xpath, NAMESPACES, variable_bindings)
           ref
         else
           raise(

--- a/spec/fixtures/unsigned-malicious.xml
+++ b/spec/fixtures/unsigned-malicious.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo' or 1=1 or ''='">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -65,6 +65,16 @@ describe Xmldsig::Reference do
       expect { reference.referenced_node }.
         to raise_error(Xmldsig::Reference::ReferencedNodeNotFound)
     end
+
+    it "raises ReferencedNodeNotFound when the reference node is malicious" do
+      malicious_document = Nokogiri::XML::Document.parse File.read("spec/fixtures/unsigned-malicious.xml")
+      node = document.at_xpath('//*[@ID]')
+      node.remove_attribute('ID')
+      node.set_attribute('MyID', 'foobar')
+      malicious_reference = Xmldsig::Reference.new(malicious_document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES), 'MyID')
+      expect { malicious_reference.referenced_node }.
+        to raise_error(Xmldsig::Reference::ReferencedNodeNotFound)
+    end
   end
 
   describe "#reference_uri" do


### PR DESCRIPTION
So after a bit more playing with it I was able to inject some xpath.

The custom id attribute route is a bit easier to do this with. 

Without this patch the spec fails:

```ShellSession
  1) Xmldsig::Reference#referenced_node raises ReferencedNodeNotFound when the reference node is malicious
     Failure/Error: expect { malicious_reference.referenced_node }.
       expected Xmldsig::Reference::ReferencedNodeNotFound but nothing was raised
```

with this patch: 

```ShellSession
Finished in 0.21126 seconds (files took 0.29924 seconds to load)
63 examples, 0 failures
```

I'm not exactly sure how dangerous this could actually be though.