### PR TITLE
Added http://www.w3.org/2001/10/xml-exc-c14n#WithComments Transform

### DIFF
--- a/lib/xmldsig/canonicalizer.rb
+++ b/lib/xmldsig/canonicalizer.rb
@@ -1,22 +1,24 @@
 module Xmldsig
   class Canonicalizer
-    attr_accessor :node, :method, :inclusive_namespaces
+    attr_accessor :node, :method, :inclusive_namespaces, :with_comments
 
-    def initialize(node, method = nil, inclusive_namespaces = [])
+    def initialize(node, method = nil, inclusive_namespaces = [], with_comments = false)
       @node = node
       @method = method
       @inclusive_namespaces = inclusive_namespaces
+      @with_comments = with_comments
     end
 
     def canonicalize
-      node.canonicalize(mode(method), inclusive_namespaces)
+      node.canonicalize(mode(method), inclusive_namespaces, with_comments)
     end
 
     private
 
     def mode(method)
       case method
-        when "http://www.w3.org/2001/10/xml-exc-c14n#"
+        when "http://www.w3.org/2001/10/xml-exc-c14n#",
+             "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
           Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
         when "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
           Nokogiri::XML::XML_C14N_1_0

--- a/lib/xmldsig/transforms.rb
+++ b/lib/xmldsig/transforms.rb
@@ -19,6 +19,8 @@ module Xmldsig
             "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
             "http://www.w3.org/2006/12/xml-c14n11"
           Transforms::Canonicalize.new(node, transform_node)
+        when "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+          Transforms::Canonicalize.new(node, transform_node, true)
       end
     end
 

--- a/lib/xmldsig/transforms/canonicalize.rb
+++ b/lib/xmldsig/transforms/canonicalize.rb
@@ -2,7 +2,7 @@ module Xmldsig
   class Transforms < Array
     class Canonicalize < Transform
       def transform
-        self.node = Canonicalizer.new(node, algorithm, inclusive_namespaces).canonicalize
+        self.node = Canonicalizer.new(node, algorithm, inclusive_namespaces, with_comments).canonicalize
         node
       end
 

--- a/lib/xmldsig/transforms/transform.rb
+++ b/lib/xmldsig/transforms/transform.rb
@@ -2,11 +2,12 @@ module Xmldsig
   class Transforms < Array
     class Transform
 
-      attr_accessor :node, :transform_node
+      attr_accessor :node, :transform_node, :with_comments
 
-      def initialize(node, transform_node)
+      def initialize(node, transform_node, with_comments = false)
         @node           = node
         @transform_node = transform_node
+        @with_comments  = with_comments
       end
 
       def transform

--- a/spec/fixtures/signed_xml-exc-c14n#with_comments.xml
+++ b/spec/fixtures/signed_xml-exc-c14n#with_comments.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#WithComments"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#WithComments">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/signed_document_spec.rb
+++ b/spec/lib/xmldsig/signed_document_spec.rb
@@ -72,6 +72,13 @@ describe Xmldsig::SignedDocument do
         certificate.public_key.verify(OpenSSL::Digest::SHA256.new, signature_value, data)
       end.should be == true
     end
+
+    it "validates a document with a http://www.w3.org/2001/10/xml-exc-c14n#WithComments transform" do
+      unsigned_xml_with_comments = File.read("spec/fixtures/signed_xml-exc-c14n#with_comments.xml")
+      unsigned_documents_with_comments = Xmldsig::SignedDocument.new(unsigned_xml_with_comments)
+      signed_xml_with_comments = unsigned_documents_with_comments.sign(private_key)
+      Xmldsig::SignedDocument.new(signed_xml_with_comments).validate(certificate).should be == true
+    end
   end
 
   describe "#sign" do


### PR DESCRIPTION
Hello,

i created this PR to implement another Transform: "http://www.w3.org/2001/10/xml-exc-c14n#WithComments". The library now recognizes this transform and executes the Nokogiri canonicalization with a third parameter 'with_comments'.
My use case uses this kind of transform and the lib currently breaks with an 'NoMethodError: undefined method `transform' for nil:NilClass' in transforms.rb:7, because it can't handle this kind of transform.

I hope that this one gets merged.