### PR TITLE
Add support for additional SHA2 algorithms

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -58,8 +58,10 @@ module Xmldsig
     def digest_method
       algorithm = reference.at_xpath("descendant::ds:DigestMethod", NAMESPACES).get_attribute("Algorithm")
       case algorithm
+        when "http://www.w3.org/2001/04/xmlenc#sha512"
+          Digest::SHA512
         when "http://www.w3.org/2001/04/xmlenc#sha256"
-          Digest::SHA2
+          Digest::SHA256
         when "http://www.w3.org/2000/09/xmldsig#sha1"
           Digest::SHA1
       end

--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -72,6 +72,10 @@ module Xmldsig
     def signature_method
       algorithm = signature_algorithm && signature_algorithm =~ /sha(.*?)$/i && $1.to_i
       case algorithm
+        when 512
+          OpenSSL::Digest::SHA512
+        when 384
+          OpenSSL::Digest::SHA384
         when 256 then
           OpenSSL::Digest::SHA256
         else

--- a/spec/fixtures/unsigned-sha1.xml
+++ b/spec/fixtures/unsigned-sha1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned-sha256.xml
+++ b/spec/fixtures/unsigned-sha256.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned-sha384.xml
+++ b/spec/fixtures/unsigned-sha384.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned-sha512.xml
+++ b/spec/fixtures/unsigned-sha512.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -82,4 +82,22 @@ describe Xmldsig::Reference do
       reference.reference_uri.should == "#foo"
     end
   end
+
+  ["sha1", "sha256", "sha512"].each do |algorithm|
+    describe "digest method #{algorithm}" do
+      let(:document) { Nokogiri::XML::Document.parse File.read("spec/fixtures/unsigned-#{algorithm}.xml") }
+      let(:reference) { Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES)) }
+
+      it "uses the correct digest algorithm" do
+        case algorithm
+        when "sha512"
+          reference.digest_method.should == Digest::SHA512
+        when "sha256"
+          reference.digest_method.should == Digest::SHA256
+        when "sha1"
+          reference.digest_method.should == Digest::SHA1
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/xmldsig/signature_spec.rb
+++ b/spec/lib/xmldsig/signature_spec.rb
@@ -97,4 +97,24 @@ describe Xmldsig::Signature do
       signature.errors.should be_empty
     end
   end
+
+  ["sha1", "sha256", "sha384", "sha512"].each do |algorithm|
+    describe "sign method #{algorithm}" do
+      let(:document) { Nokogiri::XML::Document.parse File.read("spec/fixtures/unsigned-#{algorithm}.xml") }
+      let(:signature_node) { document.at_xpath("//ds:Signature", Xmldsig::NAMESPACES) }
+      let(:signature) { Xmldsig::Signature.new(signature_node) }
+
+      it "uses the correct signature algorithm" do
+        signature.sign do |data, signature_algorithm|
+          case algorithm
+          when "sha1"
+            signature_algorithm.should == "http://www.w3.org/2000/09/xmldsig#rsa-#{algorithm}"
+          else
+            signature_algorithm.should == "http://www.w3.org/2001/04/xmldsig-more#rsa-#{algorithm}"
+          end
+          private_key.sign(OpenSSL::Digest.new(algorithm).new, data)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
For signing SHA384 and SHA512 also are supported in RFC 4051 for XMLDsig: https://www.ietf.org/rfc/rfc4051.txt.

As digest algorithm http://www.w3.org/2001/04/xmlenc also supports SHA512 (but not SHA384), so this is added too.