### PR TITLE
Add JRuby support for all canonizalization methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 .idea
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 2.3.0
   - 2.2.4
+  - jruby-9.1.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 group :test, :development do
   gem 'simplecov'
   gem 'rspec'
-  gem 'guard-rspec'
+  gem 'guard-rspec', platform: :mri
   gem 'rb-fsevent', '~> 0.9.1'
   gem 'rake'
 end

--- a/lib/xmldsig/canonicalizer.rb
+++ b/lib/xmldsig/canonicalizer.rb
@@ -4,7 +4,7 @@ module Xmldsig
     end
     attr_accessor :node, :method, :inclusive_namespaces, :with_comments
 
-    def initialize(node, method = nil, inclusive_namespaces = [], with_comments = false)
+    def initialize(node, method = nil, inclusive_namespaces = nil, with_comments = false)
       @node                 = node
       @method               = method
       @inclusive_namespaces = inclusive_namespaces
@@ -18,26 +18,16 @@ module Xmldsig
     private
 
     def mode(method)
-      if RUBY_PLATFORM == "java"
-        case method
-          when "http://www.w3.org/2001/10/xml-exc-c14n#",
-              "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
-            Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
-          else
-            raise UnsupportedException.new("Canonicalizer method #{method} unsupported in JRuby")
-        end
+      case method
+      when "http://www.w3.org/2001/10/xml-exc-c14n#",
+           "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+        Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
+      when "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
+        Nokogiri::XML::XML_C14N_1_0
+      when "http://www.w3.org/2006/12/xml-c14n11"
+        Nokogiri::XML::XML_C14N_1_1
       else
-        case method
-          when "http://www.w3.org/2001/10/xml-exc-c14n#",
-              "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
-            Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
-          when "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"
-            Nokogiri::XML::XML_C14N_1_0
-          when "http://www.w3.org/2006/12/xml-c14n11"
-            Nokogiri::XML::XML_C14N_1_1
-          else
-            Nokogiri::XML::XML_C14N_1_0
-        end
+        Nokogiri::XML::XML_C14N_1_0
       end
     end
   end

--- a/lib/xmldsig/transforms/canonicalize.rb
+++ b/lib/xmldsig/transforms/canonicalize.rb
@@ -17,7 +17,7 @@ module Xmldsig
         if inclusive_namespaces && inclusive_namespaces.has_attribute?("PrefixList")
           inclusive_namespaces.get_attribute("PrefixList").to_s.split(" ")
         else
-          []
+          nil
         end
       end
     end

--- a/lib/xmldsig/version.rb
+++ b/lib/xmldsig/version.rb
@@ -1,3 +1,3 @@
 module Xmldsig
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
- Change the `inclusive_namespaces` default to nil. This resolves nil type errors.
- Add full canonicalization method support for JRuby with `Nokogiri::XML::XML_C14N_1_0`
as the catch all.
- Ensure all tests pass on JRuby 9.1.5.0 and MRI 2.3.1
- Add platform labels for gems that only work on MRI in Gemfile.
- Bump patch version