### PR TITLE
Update README to indicate that validate is boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ end
 # Validation
 
 signed_document = Xmldsig::SignedDocument.new(signed_xml)
-signed_document.validate(certificate)
+document_validates = signed_document.validate(certificate)
 
 # With block
 signed_document = Xmldsig::SignedDocument.new(signed_xml)
 signed_document.validate do |signature_value, data|
-  certificate.public_key.verify(OpenSSL::Digest::SHA256.new, signature_value, data)
+  document_validates = certificate.public_key.verify(OpenSSL::Digest::SHA256.new, signature_value, data)
 end
 
 # Custom ID attribute


### PR DESCRIPTION
I hit a pretty significant bug because, based on the README, I expected `validate` to throw if the document didn't validate.

Update the README to suggest that checking the return of the `validate` method is necessary.