### PR TITLE
Use strict_encode64 instead of encode64

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -69,7 +69,7 @@ module Xmldsig
 
     def digest_value=(digest_value)
       reference.at_xpath("descendant::ds:DigestValue", NAMESPACES).content =
-          Base64.encode64(digest_value).chomp
+          Base64.strict_encode64(digest_value).chomp
     end
 
     def transforms

--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -85,7 +85,7 @@ module Xmldsig
 
     def signature_value=(signature_value)
       signature.at_xpath("descendant::ds:SignatureValue", NAMESPACES).content =
-          Base64.encode64(signature_value).chomp
+          Base64.strict_encode64(signature_value).chomp
     end
 
     def validate_schema


### PR DESCRIPTION
strict_encode64 should really be ruby's default; some (stupid) parsers can break on newlines in base64'd text.

btw, thanks for your code! Your library is working on healthcare.gov helping people get healthcare :)