### PR TITLE
support SHA* namespaces and default to SHA256.

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -57,13 +57,15 @@ module Xmldsig
 
     def digest_method
       algorithm = reference.at_xpath("descendant::ds:DigestMethod", NAMESPACES).get_attribute("Algorithm")
-      case algorithm
-        when "http://www.w3.org/2001/04/xmlenc#sha512"
+      case algorithm =~ /sha(.*?)$/i && $1.to_i
+        when 512
           Digest::SHA512
-        when "http://www.w3.org/2001/04/xmlenc#sha256"
+        when 256
           Digest::SHA256
-        when "http://www.w3.org/2000/09/xmldsig#sha1"
+        when 1
           Digest::SHA1
+        else
+          Digest::SHA256
       end
     end
 

--- a/spec/fixtures/unsigned-invalid.xml
+++ b/spec/fixtures/unsigned-invalid.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="invalid"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned-xmlenc-sha1.xml
+++ b/spec/fixtures/unsigned-xmlenc-sha1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -83,21 +83,28 @@ describe Xmldsig::Reference do
     end
   end
 
-  ["sha1", "sha256", "sha512"].each do |algorithm|
+  ["xmlenc-sha1", "sha1", "sha256", "sha512"].each do |algorithm|
     describe "digest method #{algorithm}" do
       let(:document) { Nokogiri::XML::Document.parse File.read("spec/fixtures/unsigned-#{algorithm}.xml") }
       let(:reference) { Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES)) }
 
       it "uses the correct digest algorithm" do
-        case algorithm
-        when "sha512"
+        match = algorithm.match(/\d+/)[0].to_i
+        case match
+        when 512
           reference.digest_method.should == Digest::SHA512
-        when "sha256"
+        when 256
           reference.digest_method.should == Digest::SHA256
-        when "sha1"
+        when 1
           reference.digest_method.should == Digest::SHA1
         end
       end
     end
+  end
+
+  it 'defaults to SHA256 for invalid algorithms' do
+    document = Nokogiri::XML::Document.parse(IO.read("spec/fixtures/unsigned-invalid.xml"))
+    reference = Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES))
+    reference.digest_method.should == Digest::SHA256
   end
 end


### PR DESCRIPTION
There are multiple xml namespace URI's that can describe the different SHA Digest methods. This change attempts to support the different versions. 

E.g.

http://www.w3.org/2001/04/xmlenc#sha1

I have also updated the case statement to default to SHA256 if the algorithm is not recognized. I considered also raising a meaningful error instead. I think this is better than handling a NoMethodError on NilClass [here](https://github.com/benoist/xmldsig/blob/master/lib/xmldsig/reference.rb#L52).

I'm open to suggestions.