### PR TITLE
Update to rspec 3 syntax.

### DIFF
--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -6,13 +6,13 @@ describe Xmldsig::Reference do
 
   describe "#digest_value" do
     it "returns the digest value in the xml" do
-      reference.digest_value.should == Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw=")
+      expect(reference.digest_value).to eq(Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw="))
     end
   end
 
   describe "#document" do
     it "returns the document" do
-      reference.document.should == document
+      expect(reference.document).to eq(document)
     end
   end
 
@@ -21,20 +21,22 @@ describe Xmldsig::Reference do
 
     it "sets the correct digest value" do
       reference.sign
-      reference.digest_value.should == Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw=")
+      expect(reference.digest_value).to eq(Base64.decode64("ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw="))
     end
   end
 
   describe "#referenced_node" do
     it "returns the referenced_node by id" do
-      reference.referenced_node.to_s.should ==
+      expect(reference.referenced_node.to_s).to eq(
         document.at_xpath("//*[@ID='foo']").to_s
+      )
     end
 
     it "returns the referenced node by parent" do
-      reference.stub(:reference_uri).and_return("")
-      reference.referenced_node.to_s.should ==
+      allow(reference).to receive(:reference_uri).and_return("")
+      expect(reference.referenced_node.to_s).to eq(
         document.root.to_s
+      )
     end
 
     it "returns the reference node when using WS-Security style id attribute" do
@@ -43,9 +45,9 @@ describe Xmldsig::Reference do
       node['wsu:Id'] = node['ID']
       node.remove_attribute('ID')
 
-      reference.referenced_node.
-        attribute_with_ns('Id', Xmldsig::NAMESPACES['wsu']).value.
-        should == 'foo'
+      expect(reference.referenced_node.
+        attribute_with_ns('Id', Xmldsig::NAMESPACES['wsu']).value).
+        to eq('foo')
     end
 
     it "returns the reference node when using a custom id attribute" do
@@ -54,8 +56,9 @@ describe Xmldsig::Reference do
       node.set_attribute('MyID', 'foo')
       reference = Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES), 'MyID')
 
-      reference.referenced_node.to_s.should ==
+      expect(reference.referenced_node.to_s).to eq(
         document.at_xpath("//*[@MyID='foo']").to_s
+      )
     end
 
     it "raises ReferencedNodeNotFound when the refenced node is not present" do
@@ -79,7 +82,7 @@ describe Xmldsig::Reference do
 
   describe "#reference_uri" do
     it "returns the reference uri" do
-      reference.reference_uri.should == "#foo"
+      expect(reference.reference_uri).to eq("#foo")
     end
   end
 
@@ -92,11 +95,11 @@ describe Xmldsig::Reference do
         match = algorithm.match(/\d+/)[0].to_i
         case match
         when 512
-          reference.digest_method.should == Digest::SHA512
+          expect(reference.digest_method).to eq(Digest::SHA512)
         when 256
-          reference.digest_method.should == Digest::SHA256
+          expect(reference.digest_method).to eq(Digest::SHA256)
         when 1
-          reference.digest_method.should == Digest::SHA1
+          expect(reference.digest_method).to eq(Digest::SHA1)
         end
       end
     end
@@ -105,6 +108,6 @@ describe Xmldsig::Reference do
   it 'defaults to SHA256 for invalid algorithms' do
     document = Nokogiri::XML::Document.parse(IO.read("spec/fixtures/unsigned-invalid.xml"))
     reference = Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES))
-    reference.digest_method.should == Digest::SHA256
+    expect(reference.digest_method).to eq(Digest::SHA256)
   end
 end

--- a/spec/lib/xmldsig/signed_document_spec.rb
+++ b/spec/lib/xmldsig/signed_document_spec.rb
@@ -12,7 +12,7 @@ describe Xmldsig::SignedDocument do
   describe "#initialize" do
     it "sets the document to a nokogiri document" do
       document = described_class.new(signed_xml)
-      document.document.should be_a(Nokogiri::XML::Document)
+      expect(document.document).to be_a(Nokogiri::XML::Document)
     end
 
     it "raises on badly formed XML" do
@@ -24,13 +24,13 @@ describe Xmldsig::SignedDocument do
       EOXML
       expect {
         described_class.new(badly_formed)
-      }.to raise_error
+      }.to raise_error(Nokogiri::XML::SyntaxError)
     end
 
     it "accepts a nokogiri document" do
       doc             = Nokogiri::XML(unsigned_xml)
       signed_document = described_class.new(doc)
-      signed_document.document.should be_a(Nokogiri::XML::Document)
+      expect(signed_document.document).to be_a(Nokogiri::XML::Document)
     end
   end
 
@@ -39,59 +39,59 @@ describe Xmldsig::SignedDocument do
     let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml) }
 
     it "returns only the signed nodes" do
-      signed_document.signatures.should be_all { |signature| signature.is_a?(Xmldsig::Signature) }
+      expect(signed_document.signatures).to be_all { |signature| signature.is_a?(Xmldsig::Signature) }
     end
 
     it "returns the outer signatures first" do
-      unsigned_document.signatures.first.references.first.reference_uri.should == '#foo'
+      expect(unsigned_document.signatures.first.references.first.reference_uri).to eq('#foo')
     end
   end
 
   describe "#signed_nodes" do
     it "returns only the signed nodes" do
-      signed_document.signed_nodes.collect(&:name).should == %w(Foo)
+      expect(signed_document.signed_nodes.collect(&:name)).to eq(%w(Foo))
     end
   end
 
   describe "#validate" do
     it "returns true if the signature and digest value are correct" do
-      signed_document.validate(certificate).should be == true
+      expect(signed_document.validate(certificate)).to eq(true)
     end
 
     it "returns false if the certificate is not valid" do
-      signed_document.validate(other_certificate).should be == false
+      expect(signed_document.validate(other_certificate)).to eq(false)
     end
 
     it "returns false if there are no signatures and validation is strict" do
       xml_without_signature = Xmldsig::SignedDocument.new('<foo></foo>')
-      xml_without_signature.validate(certificate).should be == false
+      expect(xml_without_signature.validate(certificate)).to eq(false)
     end
 
     it "accepts a block" do
-      signed_document.validate do |signature_value, data|
+      expect(signed_document.validate do |signature_value, data|
         certificate.public_key.verify(OpenSSL::Digest::SHA256.new, signature_value, data)
-      end.should be == true
+      end).to eq(true)
     end
 
     it "validates a document with a http://www.w3.org/2001/10/xml-exc-c14n#WithComments transform" do
       unsigned_xml_with_comments       = File.read("spec/fixtures/signed_xml-exc-c14n#with_comments.xml")
       unsigned_documents_with_comments = Xmldsig::SignedDocument.new(unsigned_xml_with_comments)
       signed_xml_with_comments         = unsigned_documents_with_comments.sign(private_key)
-      Xmldsig::SignedDocument.new(signed_xml_with_comments).validate(certificate).should be == true
+      expect(Xmldsig::SignedDocument.new(signed_xml_with_comments).validate(certificate)).to eq(true)
     end
   end
 
   describe "#sign" do
     it "returns a signed document" do
       signed_document = unsigned_document.sign(private_key)
-      Xmldsig::SignedDocument.new(signed_document).validate(certificate).should be == true
+      expect(Xmldsig::SignedDocument.new(signed_document).validate(certificate)).to eq(true)
     end
 
     it "accepts a block" do
       signed_document = unsigned_document.sign do |data|
         private_key.sign(OpenSSL::Digest::SHA256.new, data)
       end
-      Xmldsig::SignedDocument.new(signed_document).validate(certificate).should be == true
+      expect(Xmldsig::SignedDocument.new(signed_document).validate(certificate)).to eq(true)
     end
 
     context 'with the force false' do
@@ -102,9 +102,9 @@ describe Xmldsig::SignedDocument do
       let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml) }
 
       it 'only signs the root signature and leaves the nested signature intact' do
-        signed_document.signatures.first.valid?(certificate).should be == true
-        signed_document.signatures.last.valid?(certificate).should be == false
-        signed_document.signatures.last.signature_value.should be == unsigned_document.signatures.last.signature_value
+        expect(signed_document.signatures.first.valid?(certificate)).to eq(true)
+        expect(signed_document.signatures.last.valid?(certificate)).to eq(false)
+        expect(signed_document.signatures.last.signature_value).to eq(unsigned_document.signatures.last.signature_value)
       end
     end
 
@@ -116,9 +116,9 @@ describe Xmldsig::SignedDocument do
       let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml) }
 
       it 'only signs the root signature and leaves the nested signature intact' do
-        signed_document.signatures.first.valid?(certificate).should be == true
-        signed_document.signatures.last.valid?(certificate).should be == true
-        signed_document.signatures.last.signature_value.should be != unsigned_document.signatures.last.signature_value
+        expect(signed_document.signatures.first.valid?(certificate)).to eq(true)
+        expect(signed_document.signatures.last.valid?(certificate)).to eq(true)
+        expect(signed_document.signatures.last.signature_value).to_not be(unsigned_document.signatures.last.signature_value)
       end
     end
   end
@@ -129,17 +129,17 @@ describe Xmldsig::SignedDocument do
     let(:signed_document) { unsigned_document.sign(private_key) }
 
     it "when signed should be valid" do
-      Xmldsig::SignedDocument.new(signed_document).validate(certificate).should be == true
+      expect(Xmldsig::SignedDocument.new(signed_document).validate(certificate)).to eq(true)
     end
 
     it "should sign 2 elements" do
-      unsigned_document.signed_nodes.count.should == 2
+      expect(unsigned_document.signed_nodes.count).to eq(2)
     end
 
     it "allows individual signs" do
       unsigned_document.signatures.last.sign(private_key)
-      unsigned_document.validate(certificate).should be == false
-      unsigned_document.signatures.last.valid?(certificate).should be == true
+      expect(unsigned_document.validate(certificate)).to eq(false)
+      expect(unsigned_document.signatures.last.valid?(certificate)).to eq(true)
     end
   end
 

--- a/spec/lib/xmldsig/transforms/enveloped_signature_spec.rb
+++ b/spec/lib/xmldsig/transforms/enveloped_signature_spec.rb
@@ -10,9 +10,9 @@ describe Xmldsig::Transforms::EnvelopedSignature do
     described_class.new(node_with_nested_signature, nil).transform
 
     remaining_signatures = node_with_nested_signature.xpath('descendant::ds:Signature', Xmldsig::NAMESPACES)
-    remaining_signatures.count.should == 1
+    expect(remaining_signatures.count).to eq(1)
     signature = Xmldsig::Signature.new(remaining_signatures.first)
 
-    signature.references.first.reference_uri.should == '#baz'
+    expect(signature.references.first.reference_uri).to eq('#baz')
   end
 end

--- a/spec/lib/xmldsig/transforms/transform_spec.rb
+++ b/spec/lib/xmldsig/transforms/transform_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Xmldsig::Transforms::Transform do
 
   it "raises a warning when transform is called" do
-    described_class.any_instance.should_receive(:warn)
+    expect_any_instance_of(described_class).to receive(:warn)
     described_class.new(nil,nil).transform
   end
 

--- a/spec/lib/xmldsig_spec.rb
+++ b/spec/lib/xmldsig_spec.rb
@@ -12,11 +12,11 @@ describe Xmldsig do
         let(:signed_document) { unsigned_document.sign(private_key) }
 
         it "should be signable an validateable" do
-          Xmldsig::SignedDocument.new(signed_document).validate(certificate).should be == true
+          expect(Xmldsig::SignedDocument.new(signed_document).validate(certificate)).to eq(true)
         end
 
         it 'should have at least 1 signature element' do
-          Xmldsig::SignedDocument.new(signed_document).signatures.count.should >= 1
+          expect(Xmldsig::SignedDocument.new(signed_document).signatures.count).to be >= 1
         end
       end
     end
@@ -30,7 +30,7 @@ describe Xmldsig do
         let(:certificate) { OpenSSL::X509::Certificate.new(File.read(document.gsub('.txt', '.cert'))) }
 
         it "should be validateable" do
-          signed_document.validate(certificate).should be == true
+          expect(signed_document.validate(certificate)).to eq(true)
         end
       end
     end
@@ -64,11 +64,11 @@ describe Xmldsig do
       let(:signed_document) { unsigned_document.sign(private_key) }
 
       it "should be signable an validateable" do
-        Xmldsig::SignedDocument.new(signed_document, :id_attr => 'MyID').validate(certificate).should be == true
+        expect(Xmldsig::SignedDocument.new(signed_document, :id_attr => 'MyID').validate(certificate)).to eq(true)
       end
 
       it 'should have a signature element' do
-        Xmldsig::SignedDocument.new(signed_document, :id_attr => 'MyID').signatures.count.should == 1
+        expect(Xmldsig::SignedDocument.new(signed_document, :id_attr => 'MyID').signatures.count).to eq(1)
       end
     end
 
@@ -77,7 +77,7 @@ describe Xmldsig do
       let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml, :id_attr => 'MyID') }
 
       it "should be validateable" do
-        signed_document.validate(certificate).should be == true
+        expect(signed_document.validate(certificate)).to eq(true)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ SimpleCov.start
 require 'xmldsig'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
This is a very cosmetic change, but it removes a lot of the rspec deprecation warnings. I used [transpec](https://github.com/yujinakayama/transpec) to do the conversion.

Before:

```bash
λ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 32934
.......................................................WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<Nokogiri::XML::SyntaxError: Premature end of data in tag root line 1>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/mo/development/gh/xmldsig/spec/lib/xmldsig/signed_document_spec.rb:25:in `block (3 levels) in <top (required)>'.
.....................

Deprecation Warnings:

RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/mo/development/gh/xmldsig/spec/lib/xmldsig/transforms/enveloped_signature_spec.rb:13:in `block (2 levels) in <top (required)>'.

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/mo/development/gh/xmldsig/spec/lib/xmldsig/signature_spec.rb:81:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

3 deprecation warnings total

Finished in 0.29042 seconds (files took 0.16389 seconds to load)
76 examples, 0 failures

Randomized with seed 32934
```

After:

```bash
λ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 509
............................................................................

Finished in 0.28018 seconds (files took 0.15732 seconds to load)
76 examples, 0 failures

Randomized with seed 509
```