### PR TITLE
Allow all 1.x.y versions of Nokogiri

### DIFF
--- a/xmldsig.gemspec
+++ b/xmldsig.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Xmldsig::VERSION
 
-  gem.add_dependency("nokogiri", '~> 1.6.8')
+  gem.add_dependency("nokogiri", '>= 1.6.8', '< 2.0.0')
 end


### PR DESCRIPTION
We want to upgrade our application to Nokogiri 1.7.1, but this library prevents us from doing so. I updated the gemspec to allow all 1.x.y from 1.6.8. All tests run succesful for 1.7.1. I don't know if the upper limit of 2.0.0 is too wide, is there any reason to tie to a specific minor version of Nokogiri?