### PR TITLE
Set required ruby version

### DIFF
--- a/xmldsig.gemspec
+++ b/xmldsig.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.require_paths = ["lib"]
   gem.version       = Xmldsig::VERSION
+  
+  gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency("nokogiri", '>= 1.6.8', '< 2.0.0')
 end


### PR DESCRIPTION
This required ruby version matches that of Nokogiri 1.6.8.

On ruby 1.8.7 we tried using xmldsig (v0.4.1, because we had to use nokogiri 1.5.0) and encountered failures because of syntax incompatibilities with ruby 1.8.x. This change clarifies that xmldsig does not support ruby versions that old.