### PR TITLE
Add the possibility to validate documents when the X509SerialNumber has a large serial number size

### DIFF
--- a/lib/xmldsig.rb
+++ b/lib/xmldsig.rb
@@ -17,6 +17,7 @@ module Xmldsig
   end
 
   XSD_FILE = File.read(File.expand_path('../xmldsig/xmldsig-core-schema.xsd', __FILE__))
+  XSD_X509_SERIAL_FIX_FILE = File.read(File.expand_path('../xmldsig/xmldsig-core-schema-x509-serial-fix.xsd', __FILE__))
 end
 
 require "xmldsig/canonicalizer"

--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -30,10 +30,10 @@ module Xmldsig
       Base64.decode64 signature.at_xpath("descendant::ds:SignatureValue", NAMESPACES).content
     end
 
-    def valid?(certificate = nil, &block)
+    def valid?(certificate = nil, schema = nil, &block)
       @errors = []
       references.each { |r| r.errors = [] }
-      validate_schema
+      validate_schema(schema)
       validate_digest_values
       validate_signature_value(certificate, &block)
       errors.empty?
@@ -88,9 +88,9 @@ module Xmldsig
           Base64.strict_encode64(signature_value).chomp
     end
 
-    def validate_schema
+    def validate_schema(schema)
       doc = Nokogiri::XML::Document.parse(signature.canonicalize)
-      errors = Nokogiri::XML::Schema.new(Xmldsig::XSD_FILE).validate(doc)
+      errors = Nokogiri::XML::Schema.new(schema || Xmldsig::XSD_FILE).validate(doc)
       raise Xmldsig::SchemaError.new(errors.first.message) if errors.any?
     end
 

--- a/lib/xmldsig/signed_document.rb
+++ b/lib/xmldsig/signed_document.rb
@@ -12,8 +12,8 @@ module Xmldsig
       @force    = options[:force]
     end
 
-    def validate(certificate = nil, &block)
-      signatures.any? && signatures.all? { |signature| signature.valid?(certificate, &block) }
+    def validate(certificate = nil, schema = nil, &block)
+      signatures.any? && signatures.all? { |signature| signature.valid?(certificate, schema, &block) }
     end
 
     def sign(private_key = nil, instruct = true, &block)

--- a/lib/xmldsig/xmldsig-core-schema-x509-serial-fix.xsd
+++ b/lib/xmldsig/xmldsig-core-schema-x509-serial-fix.xsd
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+<!DOCTYPE schema
+PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
+[
+<!ATTLIST schema
+xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+<!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+<!ENTITY % p ''>
+<!ENTITY % s ''>
+]>
+-->
+<!-- Schema for XML Signatures
+http://www.w3.org/2000/09/xmldsig#
+$Revision: 4 $ on $Date: 2004-12-16 12:08:17 -0500 (Thu, 16 Dec 2004) $ by $Author: marcgratacos $
+Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+of Technology, Institut National de Recherche en Informatique et en
+Automatique, Keio University). All Rights Reserved.
+http://www.w3.org/Consortium/Legal/
+This document is governed by the W3C Software License [1] as described
+in the FAQ [2].
+[1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+[2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+<schema elementFormDefault="qualified" targetNamespace="http://www.w3.org/2000/09/xmldsig#" version="0.1" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <!-- Basic Types Defined for Signatures -->
+    <simpleType name="CryptoBinary">
+        <restriction base="base64Binary" />
+    </simpleType>
+    <!-- Start Signature -->
+    <element name="Signature" type="ds:SignatureType" />
+    <complexType name="SignatureType">
+        <sequence>
+            <element ref="ds:SignedInfo" />
+            <element ref="ds:SignatureValue" />
+            <element minOccurs="0" ref="ds:KeyInfo" />
+            <element maxOccurs="unbounded" minOccurs="0" ref="ds:Object" />
+        </sequence>
+        <attribute name="Id" type="ID" use="optional" />
+    </complexType>
+    <element name="SignatureValue" type="ds:SignatureValueType" />
+    <complexType name="SignatureValueType">
+        <simpleContent>
+            <extension base="base64Binary">
+                <attribute name="Id" type="ID" use="optional" />
+            </extension>
+        </simpleContent>
+    </complexType>
+    <!-- Start SignedInfo -->
+    <element name="SignedInfo" type="ds:SignedInfoType" />
+    <complexType name="SignedInfoType">
+        <sequence>
+            <element ref="ds:CanonicalizationMethod" />
+            <element ref="ds:SignatureMethod" />
+            <element maxOccurs="unbounded" ref="ds:Reference" />
+        </sequence>
+        <attribute name="Id" type="ID" use="optional" />
+    </complexType>
+    <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType" />
+    <complexType mixed="true" name="CanonicalizationMethodType">
+        <sequence>
+            <any maxOccurs="unbounded" minOccurs="0" namespace="##any" />
+            <!-- (0,unbounded) elements from (1,1) namespace -->
+        </sequence>
+        <attribute name="Algorithm" type="anyURI" use="required" />
+    </complexType>
+    <element name="SignatureMethod" type="ds:SignatureMethodType" />
+    <complexType mixed="true" name="SignatureMethodType">
+        <sequence>
+            <element minOccurs="0" name="HMACOutputLength" type="ds:HMACOutputLengthType" />
+            <any maxOccurs="unbounded" minOccurs="0" namespace="##other" />
+            <!-- (0,unbounded) elements from (1,1) external namespace -->
+        </sequence>
+        <attribute name="Algorithm" type="anyURI" use="required" />
+    </complexType>
+    <!-- Start Reference -->
+    <element name="Reference" type="ds:ReferenceType" />
+    <complexType name="ReferenceType">
+        <sequence>
+            <element minOccurs="0" ref="ds:Transforms" />
+            <element ref="ds:DigestMethod" />
+            <element ref="ds:DigestValue" />
+        </sequence>
+        <attribute name="Id" type="ID" use="optional" />
+        <attribute name="URI" type="anyURI" use="optional" />
+        <attribute name="Type" type="anyURI" use="optional" />
+    </complexType>
+    <element name="Transforms" type="ds:TransformsType" />
+    <complexType name="TransformsType">
+        <sequence>
+            <element maxOccurs="unbounded" ref="ds:Transform" />
+        </sequence>
+    </complexType>
+    <element name="Transform" type="ds:TransformType" />
+    <complexType mixed="true" name="TransformType">
+        <choice maxOccurs="unbounded" minOccurs="0">
+            <any namespace="##other" processContents="lax" />
+            <!-- (1,1) elements from (0,unbounded) namespaces -->
+            <element name="XPath" type="string" />
+        </choice>
+        <attribute name="Algorithm" type="anyURI" use="required" />
+    </complexType>
+    <!-- End Reference -->
+    <element name="DigestMethod" type="ds:DigestMethodType" />
+    <complexType mixed="true" name="DigestMethodType">
+        <sequence>
+            <any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax" />
+        </sequence>
+        <attribute name="Algorithm" type="anyURI" use="required" />
+    </complexType>
+    <element name="DigestValue" type="ds:DigestValueType" />
+    <simpleType name="DigestValueType">
+        <restriction base="base64Binary" />
+    </simpleType>
+    <!-- End SignedInfo -->
+    <!-- Start KeyInfo -->
+    <element name="KeyInfo" type="ds:KeyInfoType" />
+    <complexType mixed="true" name="KeyInfoType">
+        <choice maxOccurs="unbounded">
+            <element ref="ds:KeyName" />
+            <element ref="ds:KeyValue" />
+            <element ref="ds:RetrievalMethod" />
+            <element ref="ds:X509Data" />
+            <element ref="ds:PGPData" />
+            <element ref="ds:SPKIData" />
+            <element ref="ds:MgmtData" />
+            <any namespace="##other" processContents="lax" />
+            <!-- (1,1) elements from (0,unbounded) namespaces -->
+        </choice>
+        <attribute name="Id" type="ID" use="optional" />
+    </complexType>
+    <element name="KeyName" type="string" />
+    <element name="MgmtData" type="string" />
+    <element name="KeyValue" type="ds:KeyValueType" />
+    <complexType mixed="true" name="KeyValueType">
+        <choice>
+            <element ref="ds:DSAKeyValue" />
+            <element ref="ds:RSAKeyValue" />
+            <any namespace="##other" processContents="lax" />
+        </choice>
+    </complexType>
+    <element name="RetrievalMethod" type="ds:RetrievalMethodType" />
+    <complexType name="RetrievalMethodType">
+        <sequence>
+            <element minOccurs="0" ref="ds:Transforms" />
+        </sequence>
+        <attribute name="URI" type="anyURI" />
+        <attribute name="Type" type="anyURI" use="optional" />
+    </complexType>
+    <!-- Start X509Data -->
+    <element name="X509Data" type="ds:X509DataType" />
+    <complexType name="X509DataType">
+        <sequence maxOccurs="unbounded">
+            <choice>
+                <element name="X509IssuerSerial" type="ds:X509IssuerSerialType" />
+                <element name="X509SKI" type="base64Binary" />
+                <element name="X509SubjectName" type="string" />
+                <element name="X509Certificate" type="base64Binary" />
+                <element name="X509CRL" type="base64Binary" />
+                <any namespace="##other" processContents="lax" />
+            </choice>
+        </sequence>
+    </complexType>
+    <complexType name="X509IssuerSerialType">
+        <sequence>
+            <element name="X509IssuerName" type="string" />
+            <element name="X509SerialNumber" type="string" />
+        </sequence>
+    </complexType>
+    <!-- End X509Data -->
+    <!-- Begin PGPData -->
+    <element name="PGPData" type="ds:PGPDataType" />
+    <complexType name="PGPDataType">
+        <choice>
+            <sequence>
+                <element name="PGPKeyID" type="base64Binary" />
+                <element minOccurs="0" name="PGPKeyPacket" type="base64Binary" />
+                <any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax" />
+            </sequence>
+            <sequence>
+                <element name="PGPKeyPacket" type="base64Binary" />
+                <any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax" />
+            </sequence>
+        </choice>
+    </complexType>
+    <!-- End PGPData -->
+    <!-- Begin SPKIData -->
+    <element name="SPKIData" type="ds:SPKIDataType" />
+    <complexType name="SPKIDataType">
+        <sequence maxOccurs="unbounded">
+            <element name="SPKISexp" type="base64Binary" />
+            <any minOccurs="0" namespace="##other" processContents="lax" />
+        </sequence>
+    </complexType>
+    <!-- End SPKIData -->
+    <!-- End KeyInfo -->
+    <!-- Start Object (Manifest, SignatureProperty) -->
+    <element name="Object" type="ds:ObjectType" />
+    <complexType mixed="true" name="ObjectType">
+        <sequence maxOccurs="unbounded" minOccurs="0">
+            <any namespace="##any" processContents="lax" />
+        </sequence>
+        <attribute name="Id" type="ID" use="optional" />
+        <attribute name="MimeType" type="string" use="optional" />
+        <attribute name="Encoding" type="anyURI" use="optional" />
+        <!-- add a grep facet -->
+    </complexType>
+    <element name="Manifest" type="ds:ManifestType" />
+    <complexType name="ManifestType">
+        <sequence>
+            <element maxOccurs="unbounded" ref="ds:Reference" />
+        </sequence>
+        <attribute name="Id" type="ID" use="optional" />
+    </complexType>
+    <element name="SignatureProperties" type="ds:SignaturePropertiesType" />
+    <complexType name="SignaturePropertiesType">
+        <sequence>
+            <element maxOccurs="unbounded" ref="ds:SignatureProperty" />
+        </sequence>
+        <attribute name="Id" type="ID" use="optional" />
+    </complexType>
+    <element name="SignatureProperty" type="ds:SignaturePropertyType" />
+    <complexType mixed="true" name="SignaturePropertyType">
+        <choice maxOccurs="unbounded">
+            <any namespace="##other" processContents="lax" />
+            <!-- (1,1) elements from (1,unbounded) namespaces -->
+        </choice>
+        <attribute name="Target" type="anyURI" use="required" />
+        <attribute name="Id" type="ID" use="optional" />
+    </complexType>
+    <!-- End Object (Manifest, SignatureProperty) -->
+    <!-- Start Algorithm Parameters -->
+    <simpleType name="HMACOutputLengthType">
+        <restriction base="integer" />
+    </simpleType>
+    <!-- Start KeyValue Element-types -->
+    <element name="DSAKeyValue" type="ds:DSAKeyValueType" />
+    <complexType name="DSAKeyValueType">
+        <sequence>
+            <sequence minOccurs="0">
+                <element name="P" type="ds:CryptoBinary" />
+                <element name="Q" type="ds:CryptoBinary" />
+            </sequence>
+            <element minOccurs="0" name="G" type="ds:CryptoBinary" />
+            <element name="Y" type="ds:CryptoBinary" />
+            <element minOccurs="0" name="J" type="ds:CryptoBinary" />
+            <sequence minOccurs="0">
+                <element name="Seed" type="ds:CryptoBinary" />
+                <element name="PgenCounter" type="ds:CryptoBinary" />
+            </sequence>
+        </sequence>
+    </complexType>
+    <element name="RSAKeyValue" type="ds:RSAKeyValueType" />
+    <complexType name="RSAKeyValueType">
+        <sequence>
+            <element name="Modulus" type="ds:CryptoBinary" />
+            <element name="Exponent" type="ds:CryptoBinary" />
+        </sequence>
+    </complexType>
+    <!-- End KeyValue Element-types -->
+    <!-- End Signature -->
+</schema>

--- a/spec/fixtures/unsigned-x509-serial-fix.xml
+++ b/spec/fixtures/unsigned-x509-serial-fix.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509IssuerSerial>
+          <ds:X509IssuerName>issuer</ds:X509IssuerName>
+          <ds:X509SerialNumber>1234567890123456789012345</ds:X509SerialNumber>
+        </ds:X509IssuerSerial>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/signature_spec.rb
+++ b/spec/lib/xmldsig/signature_spec.rb
@@ -98,6 +98,20 @@ describe Xmldsig::Signature do
       end
       expect(signature.errors).to be_empty
     end
+
+    context "when X509SerialNumber element is longer than 24 digits" do
+      let(:document) { Nokogiri::XML::Document.parse(File.read("spec/fixtures/unsigned-x509-serial-fix.xml")) }
+
+      before { signature.sign(private_key) }
+
+      it "returns false with the default validation scheme and true with the X509 serial fix scheme" do
+        aggregate_failures do
+          expect { signature.valid?(certificate) }.to raise_error Xmldsig::SchemaError, /is not a valid value of the atomic type 'xs:integer'/
+          expect(signature.valid?(certificate, Xmldsig::XSD_X509_SERIAL_FIX_FILE)).to eq(true)
+          expect(signature.errors).to eql []
+        end
+      end
+    end
   end
 
   ["sha1", "sha256", "sha384", "sha512"].each do |algorithm|

--- a/spec/lib/xmldsig/signed_document_spec.rb
+++ b/spec/lib/xmldsig/signed_document_spec.rb
@@ -67,6 +67,10 @@ describe Xmldsig::SignedDocument do
       expect(xml_without_signature.validate(certificate)).to eq(false)
     end
 
+    it "accepts a custom schema" do
+      expect(signed_document.validate(certificate, Xmldsig::XSD_X509_SERIAL_FIX_FILE)).to eql true
+    end
+
     it "accepts a block" do
       expect(signed_document.validate do |signature_value, data|
         certificate.public_key.verify(OpenSSL::Digest::SHA256.new, signature_value, data)


### PR DESCRIPTION
**Implementation details**
Users can supply their own schema when validating the signed document. A schema with a workaround for the large serial number is provided in the contant `Xmldsig::XSD_X509_SERIAL_FIX_FILE`. This schema changes the `X509SerialNumber` element type from `integer` to `string`.

```
signed_document = Xmldsig::SignedDocument.new(signed_xml)
signed_document.validate(certificate, Xmldsig::XSD_X509_SERIAL_FIX_FILE)
```

**Problem details**
The schema validation fails when using a large serial number size in the `X509SerialNumber` element, with the following error `Xmldsig::SchemaError: Element '{http://www.w3.org/2000/09/xmldsig#}X509SerialNumber': '47340127423095676370115142060285204180' is not a valid value of the atomic type 'xs:integer'.`

Serial numbers of a X509 certificate can be up to 20 octets long.<sup>[1]</sup> The xmldsig schema defines the `X509SerialNumber` element as a `xs:integer` type. This should be fine, since the type allows a infinite value space.<sup>[2]</sup> However the `libxml2` library bundled in `nokogiri` only allows a size of 24 digits when validating the `xs:integer` type.<sup>[3]</sup> This causes the error mentioned above.

**References**
<sup>[1]</sup> http://stackoverflow.com/questions/15228666/xmldsig-x509serialnumber-too-large-to-be-an-int-fails-xsd-validation
<sup>[2]</sup> https://www.w3.org/TR/2001/REC-xmlschema-2-20010502/#integer
<sup>[3]</sup> https://mail.gnome.org/archives/xml/2008-March/msg00051.html