### PR TITLE
Include inclusive namespaces when canonicalizing signed info

### DIFF
--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -54,7 +54,20 @@ module Xmldsig
     end
 
     def canonicalized_signed_info
-      Canonicalizer.new(signed_info, canonicalization_method).canonicalize
+      Canonicalizer.new(
+        signed_info,
+        canonicalization_method,
+        inclusive_namespaces_for_canonicalization
+      ).canonicalize
+    end
+
+    def inclusive_namespaces_for_canonicalization
+      namespaces_node = signed_info.at_xpath(
+        'descendant::ds:CanonicalizationMethod/ec:InclusiveNamespaces',
+        NAMESPACES
+      )
+      return unless namespaces_node && namespaces_node.get_attribute('PrefixList')
+      namespaces_node.get_attribute('PrefixList').split(/\W+/)
     end
 
     def calculate_signature_value(private_key, &block)

--- a/spec/fixtures/signed_signature_namespace.xml
+++ b/spec/fixtures/signed_signature_namespace.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+        <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="foo"/>
+      </ds:CanonicalizationMethod>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>ftoSYFdze1AWgGHF5N9i9SFKThXkqH2AdyzA3/epbJw=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>s3yYvk1UCZkIpljdy6GZTdbOi/FvhuvCnBSYmdPb3yQmtEpww5Q2tCKgqu/9ixxf1tmyUulRrIZk0mVarQUsykrJhOKBHo8ht487c/XT+fmv+zF4JeO4fV6VsAx1cFd/qMXdDyE6nOxgW+qppeRwkdfX2N5I8COzn0fHOLp9QTo=</ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned_signature_namespace.xml
+++ b/spec/fixtures/unsigned_signature_namespace.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+        <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="foo"/>
+      </ds:CanonicalizationMethod>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#foo">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces PrefixList="foo"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/signed_document_spec.rb
+++ b/spec/lib/xmldsig/signed_document_spec.rb
@@ -125,6 +125,15 @@ describe Xmldsig::SignedDocument do
         expect(signed_document.signatures.last.signature_value).to_not be(unsigned_document.signatures.last.signature_value)
       end
     end
+
+    context 'with inclusive namespaces for the signature' do
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned_signature_namespace.xml") }
+      let(:signed_xml) { File.read("spec/fixtures/signed_signature_namespace.xml") }
+
+      it 'canonicalizes and signs correctly' do
+        expect(unsigned_document.sign(private_key)).to eq(signed_xml)
+      end
+    end
   end
 
   describe "Nested Signatures" do


### PR DESCRIPTION
I ran into this bug while trying to sign a request for an old SOAP API. Looks like the SignedInfo node can have a child that looks like this:

```xml
<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
  <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="foo"/>
</ds:CanonicalizationMethod>
```

When canonicalizing the signed info to create the signature, the `foo` namespace needs to be included. This commit adds that behavior.