### PR TITLE
Add support for cid references to external documents.

### DIFF
--- a/lib/xmldsig/signature.rb
+++ b/lib/xmldsig/signature.rb
@@ -2,14 +2,15 @@ module Xmldsig
   class Signature
     attr_accessor :signature
 
-    def initialize(signature, id_attr = nil)
+    def initialize(signature, id_attr = nil, referenced_documents = {})
       @signature = signature
       @id_attr = id_attr
+      @referenced_documents = referenced_documents
     end
 
     def references
       @references ||= signature.xpath("descendant::ds:Reference", NAMESPACES).map do |node|
-        Reference.new(node, @id_attr)
+        Reference.new(node, @id_attr, @referenced_documents)
       end
     end
 

--- a/lib/xmldsig/signed_document.rb
+++ b/lib/xmldsig/signed_document.rb
@@ -1,6 +1,6 @@
 module Xmldsig
   class SignedDocument
-    attr_accessor :document, :id_attr, :force
+    attr_accessor :document, :id_attr, :force, :referenced_documents
 
     def initialize(document, options = {})
       @document = if document.kind_of?(Nokogiri::XML::Document)
@@ -10,6 +10,7 @@ module Xmldsig
       end
       @id_attr  = options[:id_attr] if options[:id_attr]
       @force    = options[:force]
+      @referenced_documents = options.fetch(:referenced_documents, {})
     end
 
     def validate(certificate = nil, schema = nil, &block)
@@ -35,7 +36,7 @@ module Xmldsig
     def signatures
       document.xpath("//ds:Signature", NAMESPACES).
           sort { |left, right| left.ancestors.size <=> right.ancestors.size }.
-          collect { |node| Signature.new(node, @id_attr) } || []
+          collect { |node| Signature.new(node, @id_attr, referenced_documents) } || []
     end
   end
 end

--- a/spec/fixtures/signed_with_cid_reference.xml
+++ b/spec/fixtures/signed_with_cid_reference.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="cid:fooDocument">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>tdQEXD9Gb6kf4sxqvnkjKhpXzfEE96JucW4KHieJ33g=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>JI5XLfznf8BsNA5vtm0kPG5kni983qrJV1EFx4oZnb6tPvARvPbtR1oEaxnB5ROQJ6xzBuuxDsUFT1BNNUR8vL1S2qPk80USXwNhl0Cfa4mDULNw1rRhN6q82VEvAC/Hb32mvgKDLlJZymdafZhUUeEmaQj+YHsTU54kPCY5w+E=</ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/fixtures/unsigned_with_cid_reference.xml
+++ b/spec/fixtures/unsigned_with_cid_reference.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="cid:fooDocument">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig_spec.rb
+++ b/spec/lib/xmldsig_spec.rb
@@ -81,4 +81,31 @@ describe Xmldsig do
       end
     end
   end
+
+  describe "Allows passing referenced documents" do
+    let(:referenced_documents) { { 'fooDocument' => 'ABC' } }
+
+    describe "an unsigned document" do
+      let(:unsigned_xml) { File.read("spec/fixtures/unsigned_with_cid_reference.xml") }
+      let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, referenced_documents: referenced_documents) }
+      let(:signed_document) { unsigned_document.sign(private_key) }
+
+      it "should be signable an validateable" do
+        expect(Xmldsig::SignedDocument.new(signed_document, referenced_documents: referenced_documents).validate(certificate)).to eq(true)
+      end
+
+      it 'should have at least 1 signature element' do
+        expect(Xmldsig::SignedDocument.new(signed_document).signatures.count).to be >= 1
+      end
+    end
+
+    context "a signed document" do
+      let(:signed_xml) { File.read("spec/fixtures/signed_with_cid_reference.xml") }
+      let(:signed_document) { Xmldsig::SignedDocument.new(signed_xml, referenced_documents: referenced_documents) }
+
+      it "should be validateable" do
+        expect(signed_document.validate(certificate)).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is to enable support Soap with Attachments messages which have
references to other parts, which may be binary.

If the <ds:Reference> includes <ds:Transforms> then it is expected that
the passed in reference is a nokogiri document.

Thanks to @ajesler for the original work to support this.