### PR TITLE
Add id_attr to unsigned_xml of usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 ```ruby
 unsigned_xml = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
-<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#">
+<foo:Foo ID="foo" xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" MyID="foo">
   <foo:Bar>bar</foo:Bar>
   <foo:Baz>
     <foo:Qux>quuz</foo:Qux>


### PR DESCRIPTION
### Details
When I run the current Usage in the README, I get the following error in the Custom ID attribute section.
```
Xmldsig::Reference::ReferencedNodeNotFound (Could not find the referenced node foo')
```
Modified unsigned_xml to include Custom ID attribute so that it does not give an error.

### My environment
OS:Ubuntu 18.04.4 LTS
Ruby:2.6.6