### PR TITLE
Added support for retrieving uri from referenced_document when uri is external file

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -24,14 +24,9 @@ module Xmldsig
       if reference_uri && reference_uri != ""
         if @id_attr.nil? && reference_uri.start_with?("cid:")
           content_id = reference_uri[4..-1]
-          if @referenced_documents.has_key?(content_id)
-            @referenced_documents[content_id].dup
-          else
-            raise(
-                ReferencedNodeNotFound,
-                "Could not find referenced document with ContentId #{content_id}"
-            )
-          end
+          get_node_by_referenced_documents!(@referenced_documents, content_id)
+        elsif !File.extname(reference_uri).gsub('.', '').empty?
+          get_node_by_referenced_documents!(@referenced_documents, reference_uri)
         else
           id = reference_uri[1..-1]
           referenced_node_xpath = @id_attr ? "//*[@#{@id_attr}=$uri]" : "//*[@ID=$uri or @wsu:Id=$uri]"
@@ -94,6 +89,19 @@ module Xmldsig
     def validate_digest_value
       unless digest_value == calculate_digest_value
         @errors << :digest_value
+      end
+    end
+
+    private
+
+    def get_node_by_referenced_documents!(referenced_documents, content_id)
+      if referenced_documents.has_key?(content_id)
+        referenced_documents[content_id].dup
+      else
+        raise(
+            ReferencedNodeNotFound,
+            "Could not find referenced document with ContentId #{content_id}"
+        )
       end
     end
   end

--- a/spec/fixtures/unsigned_with_xml_reference.xml
+++ b/spec/fixtures/unsigned_with_xml_reference.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo:Foo xmlns:foo="http://example.com/foo#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="foo">
+  <foo:Bar>bar</foo:Bar>
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="test.xml">
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue></ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue></ds:SignatureValue>
+  </ds:Signature>
+</foo:Foo>

--- a/spec/lib/xmldsig/reference_spec.rb
+++ b/spec/lib/xmldsig/reference_spec.rb
@@ -102,6 +102,30 @@ describe Xmldsig::Reference do
         end
       end
     end
+
+    context "when the referenced node is file name" do
+      let(:document) { Nokogiri::XML::Document.parse File.read("spec/fixtures/unsigned_with_xml_reference.xml") }
+      let(:xml_document) { "<test><ing>present</ing></test>" }
+      let(:referenced_documents) { { "test.xml" => xml_document } }
+      let(:reference) { Xmldsig::Reference.new(document.at_xpath('//ds:Reference', Xmldsig::NAMESPACES), nil, referenced_documents) }
+
+      it "has the correct reference_uri" do
+        expect(reference.reference_uri).to eq "test.xml"
+      end
+
+      it "returns the document referenced by file name" do
+        expect(reference.referenced_node).to eq xml_document
+      end
+
+      context "when the document has no referenced_documents matching the referenced name" do
+        let(:referenced_documents) { Hash.new }
+
+        it "raises ReferencedNodeNotFound" do
+          expect { reference.referenced_node }.
+            to raise_error(Xmldsig::Reference::ReferencedNodeNotFound)
+        end
+      end
+    end
   end
 
   describe "#reference_uri" do


### PR DESCRIPTION
Added support for retrieving uri from referenced_document when uri is an external file name.

### Use case
#### XML
```xml
<ds:Reference URI="test.xml">
  <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
  <ds:DigestValue></ds:DigestValue>
</ds:Reference>
```
I encountered an XML with an external file name in the URI, and I was able to solve it by putting it in the hash of referred_documents and retrieving it by URI name, so I fixed it that way. The process to get them from referenced_documents already existed, so I made it into a function and reused it.