### PR TITLE
Fixed an error when transform node is missing.

### DIFF
--- a/lib/xmldsig/transforms/enveloped_signature.rb
+++ b/lib/xmldsig/transforms/enveloped_signature.rb
@@ -5,7 +5,7 @@ module Xmldsig
         signatures = node.xpath("descendant::ds:Signature", Xmldsig::NAMESPACES).
             sort { |left, right| left.ancestors.size <=> right.ancestors.size }
 
-        signatures.first.remove
+        signatures.first&.remove
         node
       end
     end

--- a/spec/fixtures/unsigned_rdf_signature.xml
+++ b/spec/fixtures/unsigned_rdf_signature.xml
@@ -1,0 +1,57 @@
+<rdf:RDF xmlns:rdf="http://www.w3c.org/rdf">
+  <DocumentResource about="test.xml" Id="main">
+    <DocumentType>main</DocumentType>
+    <Title>test.xml</Title>
+  </DocumentResource>
+  <PackageResource>
+    <ManagementInformation>
+      <Resource>
+        <ProcedureID>test</ProcedureID>
+        <ProcedureName>name</ProcedureName>
+        <ProcedureForm>form</ProcedureForm>
+        <ApplicationNumber/>
+        <ArrivalTime>
+          <Resource>
+            <Date.ISO8601/>
+            <Date.JISX0301/>
+          </Resource>
+        </ArrivalTime>
+      </Resource>
+    </ManagementInformation>
+    <Signatures>
+      <Signature Id="Signature" xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <SignedInfo>
+          <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+          <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+          <Reference URI="cid:fooDocument">
+            <Transforms>
+                <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+            </Transforms>
+            <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+            <DigestValue></DigestValue>
+          </Reference>
+          <Reference>
+            <Transforms>
+              <Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
+                <dsig:XPath xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">not (ancestor-or-self::ApplicationNumber)
+                  and not (ancestor-or-self::ArrivalTime) and not
+                  (ancestor-or-self::Signatures)
+                </dsig:XPath>
+              </Transform>
+              <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+              <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+            </Transforms>
+            <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+            <DigestValue></DigestValue>
+          </Reference>
+        </SignedInfo>
+        <SignatureValue></SignatureValue>
+        <KeyInfo>
+          <X509Data>
+            <X509Certificate></X509Certificate>
+          </X509Data>
+        </KeyInfo>
+      </Signature>
+    </Signatures>
+  </PackageResource>
+</rdf:RDF>

--- a/spec/lib/xmldsig/transforms/enveloped_signature_spec.rb
+++ b/spec/lib/xmldsig/transforms/enveloped_signature_spec.rb
@@ -1,18 +1,35 @@
 require 'spec_helper'
 
 describe Xmldsig::Transforms::EnvelopedSignature do
-  let(:unsigned_xml) { File.read('spec/fixtures/unsigned_nested_signature.xml') }
-  let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml) }
+  context "transform node is exist" do
+    let(:unsigned_xml) { File.read('spec/fixtures/unsigned_nested_signature.xml') }
+    let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml) }
+    it 'only removes the outer most signature element' do
+      node_with_nested_signature = unsigned_document.signatures.first.references.first.referenced_node
 
-  it 'only removes the outer most signature element' do
-    node_with_nested_signature = unsigned_document.signatures.first.references.first.referenced_node
+      described_class.new(node_with_nested_signature, nil).transform
 
-    described_class.new(node_with_nested_signature, nil).transform
+      remaining_signatures = node_with_nested_signature.xpath('descendant::ds:Signature', Xmldsig::NAMESPACES)
+      expect(remaining_signatures.count).to eq(1)
+      signature = Xmldsig::Signature.new(remaining_signatures.first)
 
-    remaining_signatures = node_with_nested_signature.xpath('descendant::ds:Signature', Xmldsig::NAMESPACES)
-    expect(remaining_signatures.count).to eq(1)
-    signature = Xmldsig::Signature.new(remaining_signatures.first)
+      expect(signature.references.first.reference_uri).to eq('#baz')
+    end
+  end
 
-    expect(signature.references.first.reference_uri).to eq('#baz')
+  context "Signature node is not exist" do
+    let(:unsigned_xml) { File.read('spec/fixtures/unsigned_rdf_signature.xml') }
+    let(:foo_document) { Nokogiri::XML::Document.parse "<test><ing>xml_documen1</ing></test>" }
+    let(:referenced_documents) { { "fooDocument" => foo_document } }
+    let(:unsigned_document) { Xmldsig::SignedDocument.new(unsigned_xml, referenced_documents: referenced_documents) }
+
+    it 'not error transform' do
+      first_referenced_node = unsigned_document.signatures.first.references.first.referenced_node
+
+      described_class.new(first_referenced_node, nil).transform
+
+      remaining_signatures = first_referenced_node.xpath('descendant::ds:Signature', Xmldsig::NAMESPACES)
+      expect(remaining_signatures.count).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Fixed the problem so that no error occurs even if the transform node is missing.
When the XML style is fixed, it is not possible to remove unnecessary transform tags, so we had to deal with it programmatically.
I have prepared a sample xml for testing, so please check it out!