### PR TITLE
make Xmldsig::Reference::ReferencedNodeNotFound subclass of Xmldsig::…

### DIFF
--- a/lib/xmldsig/reference.rb
+++ b/lib/xmldsig/reference.rb
@@ -2,7 +2,7 @@ module Xmldsig
   class Reference
     attr_accessor :reference, :errors, :id_attr
 
-    class ReferencedNodeNotFound < Exception;
+    class ReferencedNodeNotFound < Xmldsig::Error
     end
 
     def initialize(reference, id_attr = nil, referenced_documents = {})


### PR DESCRIPTION
…Error

it makes exception class structure easier to handle

ref #52