### PR TITLE
Ensure canonizalization is the last transform node applied

### DIFF
--- a/lib/xmldsig/transforms.rb
+++ b/lib/xmldsig/transforms.rb
@@ -1,8 +1,18 @@
 module Xmldsig
   class Transforms < Array
+    CANONIZALIZATION_ALGORITHMS = {
+      without_comments: [
+        "http://www.w3.org/2001/10/xml-exc-c14n#",
+        "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+        "http://www.w3.org/2006/12/xml-c14n11"
+      ],
+      with_comments: "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+    }.freeze
 
     def apply(node)
       @node = node
+      reorder_canonizalization!
+
       each do |transform_node|
         @node = get_transform(@node, transform_node).transform
       end
@@ -15,16 +25,26 @@ module Xmldsig
       case transform_node.get_attribute("Algorithm")
         when "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
           Transforms::EnvelopedSignature.new(node, transform_node)
-        when "http://www.w3.org/2001/10/xml-exc-c14n#",
-            "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
-            "http://www.w3.org/2006/12/xml-c14n11"
+        when *CANONIZALIZATION_ALGORITHMS[:without_comments]
           Transforms::Canonicalize.new(node, transform_node)
-        when "http://www.w3.org/2001/10/xml-exc-c14n#WithComments"
+        when CANONIZALIZATION_ALGORITHMS[:with_comments]
           Transforms::Canonicalize.new(node, transform_node, true)
         when "http://www.w3.org/TR/1999/REC-xpath-19991116"
           Transforms::XPath.new(node, transform_node)
       end
     end
 
+    def reorder_canonizalization!
+      algorithms = CANONIZALIZATION_ALGORITHMS.values.flatten
+      canonizalization = find do |transform_node|
+        algorithms.include?(transform_node.get_attribute("Algorithm"))
+      end
+
+      return if canonizalization.nil? || self[-1] == canonizalization
+
+      position = index(canonizalization)
+      delete_at(position)
+      self << canonizalization
+    end
   end
 end

--- a/spec/fixtures/unsigned/with_unsorted_canonizalization.xml
+++ b/spec/fixtures/unsigned/with_unsorted_canonizalization.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <samlp:ArtifactResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" ID="_91e79cb2e8cded9a7fd4d68dc480b49d2d1adf88" Version="2.0" IssueInstant="2013-01-17T09:02:44Z">
+      <ds:Signature>
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+          <ds:Reference>
+            <ds:Transforms>
+              <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                <ec:InclusiveNamespaces PrefixList="ds saml samlp xs"/>
+              </ds:Transform>
+              <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            </ds:Transforms>
+            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+            <ds:DigestValue></ds:DigestValue>
+          </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue></ds:SignatureValue>
+      </ds:Signature>
+      <samlp:Status>
+        <samlp:StatusCode/>
+      </samlp:Status>
+      <samlp:Response ID="_5a88b4aeb1d290c86073874278e5ef302da66739" Version="2.0" IssueInstant="2013-01-17T09:02:44Z">
+        <samlp:Status>
+          <samlp:StatusCode/>
+        </samlp:Status>
+      </samlp:Response>
+    </samlp:ArtifactResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Description same as title. When the canonicalization isn't performed as the last transformation, the resulting value is a String which doesn't accept Nokogiri methods.

Should mitigate https://github.com/benoist/xmldsig/issues/57