### PR TITLE
add info info README.md about force: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ XML
 private_key = OpenSSL::PKey::RSA.new(File.read("key.pem"))
 certificate = OpenSSL::X509::Certificate.new(File.read("certificate.cer"))
 
-unsigned_document = Xmldsig::SignedDocument.new(unsigned_xml)
+unsigned_document = Xmldsig::SignedDocument.new(unsigned_xml) # use `force: true` param to rewrite existing signature
 signed_xml = unsigned_document.sign(private_key)
 
 # With block


### PR DESCRIPTION
Hey, i through gem will rewrite already exists signarutes on my test xml but im visited a problem that it doesnt changed anything. For me it meaning that gem isn't worked, and it spend some time for undestanding that i need to remove already existing data about signature for working.

In Xmldsig::SignedDocument i see the `force` parameter which changed parameters by force and i think it's a good idea to mention it.

I think that `force` parameter always must be true but maybe good choice is to discuss about that in future.